### PR TITLE
Give PATH input more functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.2.0 (Sep 13, 2016)
+ 
+ * Support for paths within applications
+
+FEATURES:
+
+ * Allow downloading of specific files and directories in running applications
+
 ## 1.1.0 (Jul 1, 2016)
 
  * Refactor for Windows

--- a/README.md
+++ b/README.md
@@ -34,7 +34,13 @@ The downloaded app files will be put in a new directory "APP_NAME" that's create
 If "PATH" is specified, the directory or file specified will be placed directly in your working directory.
 
 ### Path Argument
-The path argument is optional but if included, should come immediately after the app name. It determines the starting directory that all the files will be downloaded from. By default, the entire app is downloaded starting from the root. However if desired, one could use **some/starting/path** to only download files within the **some/starting/path** directory. Additionally, the path can point to a single file to be downloaded if the **--file** flag is specified. Note: this works similarly to "cf files [path]". Any number of path arguments can be passed as long as they all come immideately after the app name, but they must all be directories or all be files (if the **--file** flag is specified).
+The path argument is optional but, if included, should come immediately after the app name. It determines the starting directory that all the files will be downloaded from. By default, the entire app is downloaded starting from the root. However if desired, one could use **some/starting/path** to only download files within the **path** directory. 
+
+The path can point to a single file (or be a path to a single file) to be downloaded if the **--file** flag is specified. Note: this works similarly to "cf files [path]". 
+
+The last element of a path can contain standard glob characters (*, ?, [ - ]).
+
+Any number of path arguments can be passed as long as they all come immideately after the app name, but they must all be directories or all be files (if the **--file** flag is specified).
 
 ### Flags:
 1. The **--overwrite** flag is needed if the download directory, "APP_NAME-download", is already taken. Using the flag, that directory will be overwritten.

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@
 
 ## Usage
 
-cf download APP_NAME [PATH] [--overwrite] [--file] [--verbose] [--omit omitted_path] [-i instance]
+cf download APP_NAME [PATH...] [--overwrite] [--file] [--verbose] [--omit omitted_path] [-i instance]
 
 The downloaded app files will be put in a new directory "APP_NAME" that's created within your working directory.
 If "PATH" is specified, the directory or file specified will be placed directly in your working directory.
 
 ### Path Argument
-The path argument is optional but if included, should come immediately after the app name. It determines the starting directory that all the files will be downloaded from. By default, the entire app is downloaded starting from the root. However if desired, one could use **some/starting/path** to only download files within the **some/starting/path** directory. Additionally, the path can point to a single file to be downloaded if the **--file** flag is specified. Note: this works similarly to "cf files [path]".
+The path argument is optional but if included, should come immediately after the app name. It determines the starting directory that all the files will be downloaded from. By default, the entire app is downloaded starting from the root. However if desired, one could use **some/starting/path** to only download files within the **some/starting/path** directory. Additionally, the path can point to a single file to be downloaded if the **--file** flag is specified. Note: this works similarly to "cf files [path]". Any number of path arguments can be passed as long as they all come immideately after the app name, but they must all be directories or all be files (if the **--file** flag is specified).
 
 ### Flags:
 1. The **--overwrite** flag is needed if the download directory, "APP_NAME-download", is already taken. Using the flag, that directory will be overwritten.

--- a/README.md
+++ b/README.md
@@ -28,17 +28,18 @@
 
 ## Usage
 
-cf download APP_NAME [PATH] [--overwrite] [--verbose] [--omit omitted_path] [-i instance]
+cf download APP_NAME [PATH] [--overwrite] [--file] [--verbose] [--omit omitted_path] [-i instance]
 
 The downloaded app files will put put in a new directory "APP_NAME-download" that's created within your working directory.
 
 ### Path Argument
-The path argument is optional but if included, should come immediately after the app name. It determines the starting directory that all the files will be downloaded from. By default, the entire app is downloaded starting from the root. However if desired, one could use **some/starting/path** to only download files within the **some/starting/path** directory. Additionally, the path can point to a single file to be downloaded. Note: this works similarly to "cf files [path]".
+The path argument is optional but if included, should come immediately after the app name. It determines the starting directory that all the files will be downloaded from. By default, the entire app is downloaded starting from the root. However if desired, one could use **some/starting/path** to only download files within the **some/starting/path** directory. Additionally, the path can point to a single file to be downloaded if the **--file** flag is specified. Note: this works similarly to "cf files [path]".
 
 ### Flags:
 1. The **--overwrite** flag is needed if the download directory, "APP_NAME-download", is already taken. Using the flag, that directory will be overwritten.
-2. The **--verbose** flag is used to see more detailed output as the downloads are happening.
-3. The **--omit [omitted_path]** flag is useful when certain files or directories are not wanted. You can exclude a file by typing **--omit path/to/file**. Multiple things can be omitted by delimiting the paths with semicolons and putting quotes around the entire parameter like so: **--omit "path/to/file; another/path/to/file"**
+2. The **--file** flag is needed if **PATH** points to a single file to be downloaded, and not a directory.
+3. The **--verbose** flag is used to see more detailed output as the downloads are happening.
+4. The **--omit [omitted_path]** flag is useful when certain files or directories are not wanted. You can exclude a file by typing **--omit path/to/file**. Multiple things can be omitted by delimiting the paths with semicolons and putting quotes around the entire parameter like so: **--omit "path/to/file; another/path/to/file"**
 5. The **-i [instance]** flag will download from the given app instance. By default, the instance number is 0.
 
 ***

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 cf download APP_NAME [PATH...] [--overwrite] [--file] [--verbose] [--omit omitted_path] [-i instance]
 
-The downloaded app files will be put in a new directory "APP_NAME" that's created within your working directory.
+If no "PATH" is specified, the downloaded app files will be put in a new directory "APP_NAME" that's created within your working directory.
 If "PATH" is specified, the directory or file specified will be placed directly in your working directory.
 
 ### Path Argument

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@
 
 cf download APP_NAME [PATH] [--overwrite] [--file] [--verbose] [--omit omitted_path] [-i instance]
 
-The downloaded app files will put put in a new directory "APP_NAME-download" that's created within your working directory.
+The downloaded app files will be put in a new directory "APP_NAME" that's created within your working directory.
+If "PATH" is specified, the directory or file specified will be placed directly in your working directory.
 
 ### Path Argument
 The path argument is optional but if included, should come immediately after the app name. It determines the starting directory that all the files will be downloaded from. By default, the entire app is downloaded starting from the root. However if desired, one could use **some/starting/path** to only download files within the **some/starting/path** directory. Additionally, the path can point to a single file to be downloaded if the **--file** flag is specified. Note: this works similarly to "cf files [path]".

--- a/downloader/download.go
+++ b/downloader/download.go
@@ -26,29 +26,27 @@ type Downloader interface {
 }
 
 type downloader struct {
-	cmdExec                    cmd_exec.CmdExec
-	rootWorkingDirectoryServer string
-	appName                    string
-	instance                   string
-	verbose                    bool
-	onWindows                  bool
-	failedDownloads            []string
-	filesDownloaded            int
-	parser                     dir_parser.Parser
-	wg                         *sync.WaitGroup
+	cmdExec         cmd_exec.CmdExec
+	appName         string
+	instance        string
+	verbose         bool
+	onWindows       bool
+	failedDownloads []string
+	filesDownloaded int
+	parser          dir_parser.Parser
+	wg              *sync.WaitGroup
 }
 
-func NewDownloader(cmdExec cmd_exec.CmdExec, WG *sync.WaitGroup, appName, instance, rootWorkingDirectoryServer string, verbose, onWindows bool) *downloader {
+func NewDownloader(cmdExec cmd_exec.CmdExec, WG *sync.WaitGroup, appName, instance string, verbose, onWindows bool) *downloader {
 
 	return &downloader{
-		cmdExec:                    cmdExec,
-		rootWorkingDirectoryServer: rootWorkingDirectoryServer,
-		appName:                    appName,
-		instance:                   instance,
-		verbose:                    verbose,
-		onWindows:                  onWindows,
-		parser:                     dir_parser.NewParser(cmdExec, appName, instance, onWindows, verbose),
-		wg:                         WG,
+		cmdExec:   cmdExec,
+		appName:   appName,
+		instance:  instance,
+		verbose:   verbose,
+		onWindows: onWindows,
+		parser:    dir_parser.NewParser(cmdExec, appName, instance, onWindows, verbose),
+		wg:        WG,
 	}
 }
 
@@ -77,9 +75,7 @@ func (d *downloader) Download(files, dirs []string, readPath, writePath string, 
 		fileWPath := writePath + val
 		fileRPath := readPath + val
 
-		filePath := strings.TrimPrefix(strings.TrimSuffix(fileRPath, "/"), d.rootWorkingDirectoryServer)
-
-		if filter.CheckToFilter(filePath, filterList) {
+		if filter.CheckToFilter(fileRPath, filterList) {
 			continue
 		}
 
@@ -91,9 +87,8 @@ func (d *downloader) Download(files, dirs []string, readPath, writePath string, 
 	for _, val := range dirs {
 		dirWPath := writePath + filepath.FromSlash(val)
 		dirRPath := readPath + val
-		dirPath := strings.TrimPrefix(strings.TrimSuffix(dirRPath, "/"), d.rootWorkingDirectoryServer)
 
-		if filter.CheckToFilter(dirPath, filterList) {
+		if filter.CheckToFilter(dirRPath, filterList) {
 			continue
 		}
 

--- a/downloader/download_test.go
+++ b/downloader/download_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Downloader tests", func() {
 	os.MkdirAll(currentDirectory+"/testFiles/", 0755)
 
 	cmdExec = cmd_exec_fake.NewCmdExec()
-	d = NewDownloader(cmdExec, &wg, "appName", "0", "rootWorkingDirectory", false, false)
+	d = NewDownloader(cmdExec, &wg, "appName", "0", false, false)
 
 	// downloadfile also tests the following functions
 	// WriteFile(), CheckDownload()
@@ -33,7 +33,7 @@ var _ = Describe("Downloader tests", func() {
 				writePath := currentDirectory + "/testFiles/test1.txt"
 				cmdExec.SetOutput("Getting files for app payToWin in org jstart / space koldus as email@us.ibm.com...\nOK\nHello World")
 				wg.Add(1)
-				go d.DownloadFile("", writePath, &wg)
+				go d.DownloadFile("", writePath)
 				wg.Wait()
 
 				fileContents, err := ioutil.ReadFile(writePath)
@@ -42,7 +42,7 @@ var _ = Describe("Downloader tests", func() {
 				writePath = currentDirectory + "/testFiles/test2.txt"
 				cmdExec.SetOutput("Getting files for app payToWin in org jstart / space koldus as email@us.ibm.com...\nOK\nLorem ipsum is a pseudo-Latin text used in web design, typography, layout, and printing in place of English to emphasise design elements over content. It's also called placeholder (or filler) text. It's a convenient tool for mock-ups. It helps to outline the visual elements of a document or presentation, eg typography, font, or layout. Lorem ipsum is mostly a part of a Latin text by the classical author and philosopher Cicero. Its words and letters have been changed by addition or removal, so to deliberately render its content nonsensical; it's not genuine, correct, or comprehensible Latin anymore. While lorem ipsum's still resembles classical Latin, it actually has no meaning whatsoever. As Cicero's text doesn't contain the letters K, W, or Z, alien to latin, these, and others are often inserted randomly to mimic the typographic appearence of European languages, as are digraphs not to be found in the original.")
 				wg.Add(1)
-				go d.DownloadFile("", writePath, &wg)
+				go d.DownloadFile("", writePath)
 				wg.Wait()
 
 				fileInfo, err := os.Stat(writePath)
@@ -176,7 +176,7 @@ var _ = Describe("Downloader tests", func() {
 	Describe("Test Download() Function", func() {
 		Context("download the entire directory (no filter)", func() {
 			It("should download and write the files to the testFiles Directory", func() {
-				d = NewDownloader(cmdExec, &wg, "appName", "0", "rootWorkingDirectory", false, false)
+				d = NewDownloader(cmdExec, &wg, "appName", "0", false, false)
 				readPath := currentDirectory
 				writePath := currentDirectory + "/test-download"
 
@@ -222,7 +222,7 @@ var _ = Describe("Downloader tests", func() {
 	Describe("Test Download() Function", func() {
 		Context("download the fake directory filtering out ignore.go and ignoreDir", func() {
 			It("should download and write the files to the testFiles Directory", func() {
-				d = NewDownloader(cmdExec, &wg, "appName", "0", "rootWorkingDirectory", false, false)
+				d = NewDownloader(cmdExec, &wg, "appName", "0", false, false)
 				readPath := currentDirectory
 				writePath := currentDirectory + "/test-download"
 

--- a/main.go
+++ b/main.go
@@ -107,8 +107,14 @@ func (c *DownloadPlugin) Run(cliConnection plugin.CliConnection, args []string) 
 
 	// prevent overwriting files
 	if Exists(rootWorkingDirectoryLocal) && flagVals.OverWrite_flag == false {
-		fmt.Println("\nError: destination path", rootWorkingDirectoryLocal, "already Exists and is not an empty directory.\n\nDelete it or use 'cf download APP_NAME --overwrite'")
+		fmt.Println("\nError: destination path", rootWorkingDirectoryLocal, "already exists.\n\nDelete it or rerun the command with the '--overwrite' flag.")
 		os.Exit(1)
+	}
+
+	// remove files to be overwritten
+	if flagVals.OverWrite_flag {
+		err := os.RemoveAll(rootWorkingDirectoryLocal)
+		check(err, "Cannot remove "+rootWorkingDirectoryLocal+" for overwrite.")
 	}
 
 	cmdExec := cmd_exec.NewCmdExec()
@@ -162,7 +168,7 @@ func getFailedDownloads() {
 }
 
 func GetDirectoryContext(workingDir string, copyOfArgs []string, isFile bool) (string, string) {
-	rootWorkingDirectory := workingDir + "/" + appName + "-download/"
+	rootWorkingDirectory := workingDir + "/"
 
 	// append path if provided as arguement
 	startingPath := "/"
@@ -176,6 +182,8 @@ func GetDirectoryContext(workingDir string, copyOfArgs []string, isFile bool) (s
 		}
 		rootWorkingDirectory += startingPath
 		startingPath = "/" + startingPath
+	} else {
+		rootWorkingDirectory += appName + "/"
 	}
 
 	// ensure files do not have trailing backslash

--- a/main.go
+++ b/main.go
@@ -199,10 +199,11 @@ func GetDirectoryContext(workingDir string, paths []string, isFile bool) []pathV
 	if len(paths) == 0 {
 		// create appName directory if downloading whole app
 		addPathVals := pathVal{
-			RootWorkingDirectoryLocal: filepath.FromSlash(localPath + appName + "/"),
+			RootWorkingDirectoryLocal: localPath + appName + "/",
 			StartingPathServer:        startingPath,
 		}
 
+		addPathVals.RootWorkingDirectoryLocal = filepath.FromSlash(addPathVals.RootWorkingDirectoryLocal)
 		pathVals = append(pathVals, addPathVals)
 	} else {
 		// append each path provided as an argument
@@ -217,7 +218,7 @@ func GetDirectoryContext(workingDir string, paths []string, isFile bool) []pathV
 			}
 
 			addPathVals := pathVal{
-				RootWorkingDirectoryLocal: filepath.FromSlash(localPath + filepath.Base(v)),
+				RootWorkingDirectoryLocal: localPath + filepath.Base(v),
 				StartingPathServer:        startingPath + v,
 			}
 
@@ -226,6 +227,7 @@ func GetDirectoryContext(workingDir string, paths []string, isFile bool) []pathV
 				addPathVals.RootWorkingDirectoryLocal += "/"
 			}
 
+			addPathVals.RootWorkingDirectoryLocal = filepath.FromSlash(addPathVals.RootWorkingDirectoryLocal)
 			pathVals = append(pathVals, addPathVals)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -148,7 +148,7 @@ func (c *DownloadPlugin) Run(cliConnection plugin.CliConnection, args []string) 
 
 			// start download of single file
 			wg.Add(1)
-			dloader.DownloadFile(v.StartingPathServer, v.RootWorkingDirectoryLocal, &wg)
+			dloader.DownloadFile(v.StartingPathServer, v.RootWorkingDirectoryLocal)
 		} else {
 			// parse the input directory
 			files, dirs := parser.ExecParseDir(v.StartingPathServer)
@@ -400,7 +400,9 @@ func ExpandGlobs(cmdExec cmd_exec.CmdExec, paths []string, instance string) []st
 		if strings.ContainsAny(v, "*?[]") {
 			dir := filepath.Dir(v)
 			out, _ := cmdExec.GetFile(appName, dir, instance)
+			// split the body line by line
 			body := strings.Split(string(out), "\n")
+			// the first 3 lines contain execution info from cf files and the last 2 are blank
 			body = body[3 : len(body)-2]
 
 			//iterate over glob's directory

--- a/main_test.go
+++ b/main_test.go
@@ -14,21 +14,19 @@ import (
 // unit tests of individual functions
 var _ = Describe("CfDownload", func() {
 	var args []string
+	var paths []string
 
-	BeforeEach(func() {
-		args = make([]string, 7)
-	})
-
-	Describe("Test Flag functionality", func() {
+	Describe("Test ParseArgs functionality", func() {
 
 		Context("Check if overWrite flag works", func() {
 			It("Should set the overwrite_flag", func() {
+				args = make([]string, 4)
 				args[0] = "download"
 				args[1] = "app"
 				args[2] = "app/files/htdocs"
 				args[3] = "--overwrite"
 
-				flagVals := ParseFlags(args)
+				flagVals, _ := ParseArgs(args)
 				Expect(flagVals.OverWrite_flag).To(BeTrue())
 				Expect(flagVals.File_flag).To(BeFalse())
 				Expect(flagVals.Instance_flag).To(Equal("0"))
@@ -39,11 +37,12 @@ var _ = Describe("CfDownload", func() {
 
 		Context("Check if file flag works", func() {
 			It("Should set the file_flag", func() {
+				args = make([]string, 3)
 				args[0] = "download"
 				args[1] = "app"
 				args[2] = "--file"
 
-				flagVals := ParseFlags(args)
+				flagVals, _ := ParseArgs(args)
 				Expect(flagVals.OverWrite_flag).To(BeFalse())
 				Expect(flagVals.File_flag).To(BeTrue())
 				Expect(flagVals.Instance_flag).To(Equal("0"))
@@ -54,11 +53,12 @@ var _ = Describe("CfDownload", func() {
 
 		Context("Check if verbose flag works", func() {
 			It("Should set the verbose_flag", func() {
+				args = make([]string, 3)
 				args[0] = "download"
 				args[1] = "app"
 				args[2] = "--verbose"
 
-				flagVals := ParseFlags(args)
+				flagVals, _ := ParseArgs(args)
 				Expect(flagVals.OverWrite_flag).To(BeFalse())
 				Expect(flagVals.File_flag).To(BeFalse())
 				Expect(flagVals.Instance_flag).To(Equal("0"))
@@ -69,12 +69,13 @@ var _ = Describe("CfDownload", func() {
 
 		Context("Check if instance (i) flag works", func() {
 			It("Should set the instance_flag", func() {
+				args = make([]string, 4)
 				args[0] = "download"
 				args[1] = "app"
 				args[2] = "--i"
 				args[3] = "3"
 
-				flagVals := ParseFlags(args)
+				flagVals, _ := ParseArgs(args)
 				Expect(flagVals.OverWrite_flag).To(BeFalse())
 				Expect(flagVals.File_flag).To(BeFalse())
 				Expect(flagVals.Instance_flag).To(Equal("3"))
@@ -85,12 +86,13 @@ var _ = Describe("CfDownload", func() {
 
 		Context("Check if omit flag works", func() {
 			It("Should set the omit_flag", func() {
+				args = make([]string, 4)
 				args[0] = "download"
 				args[1] = "app"
 				args[2] = "--omit"
 				args[3] = "app/node_modules"
 
-				flagVals := ParseFlags(args)
+				flagVals, _ := ParseArgs(args)
 				Expect(flagVals.OverWrite_flag).To(BeFalse())
 				Expect(flagVals.File_flag).To(BeFalse())
 				Expect(flagVals.Instance_flag).To(Equal("0"))
@@ -99,98 +101,141 @@ var _ = Describe("CfDownload", func() {
 			})
 		})
 
+		Context("Check if correct number of paths are returned", func() {
+			It("Should return 0 paths", func() {
+				args = make([]string, 2)
+				args[0] = "download"
+				args[1] = "app"
+
+				_, paths := ParseArgs(args)
+				Expect(len(paths)).To(Equal(0))
+			})
+
+			It("Should return 1 path", func() {
+				args = make([]string, 3)
+				args[0] = "download"
+				args[1] = "app"
+				args[2] = "path/to/file"
+
+				_, paths := ParseArgs(args)
+				Expect(len(paths)).To(Equal(1))
+			})
+
+			It("Should return 2 paths", func() {
+				args = make([]string, 4)
+				args[0] = "download"
+				args[1] = "app"
+				args[2] = "path/to/file"
+				args[3] = "path/to/other/file"
+
+				_, paths := ParseArgs(args)
+				Expect(len(paths)).To(Equal(2))
+			})
+		})
 	})
 
 	Describe("test directoryContext parsing", func() {
 
 		It("Should return correct strings", func() {
-			args[0] = "download"
-			args[1] = "app_name"
-			args[2] = "app/src/node"
-			args[3] = "--verbose"
+			paths = make([]string, 1)
+			paths[0] = "app/src/node"
 			currentDirectory, _ := os.Getwd()
 			currentDirectory = filepath.ToSlash(currentDirectory)
-			localPath, rootWD, startingPath := GetDirectoryContext(currentDirectory, args, false)
+			pathVals := GetDirectoryContext(currentDirectory, paths, false)
 
-			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app/src/node/")
+			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryServer, "/cf-download/app/src/node/")
 			Expect(correctSuffix).To(BeTrue())
 
-			correctSuffix = strings.HasSuffix(localPath, "/cf-download/node/")
+			correctSuffix = strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/node/")
 			Expect(correctSuffix).To(BeTrue())
 
-			Expect(startingPath).To(Equal("/app/src/node/"))
+			Expect(pathVals[0].StartingPathServer).To(Equal("/app/src/node/"))
 		})
 
 		It("should still return /app/src/node/ for startingPath (INPUT has leading and trailing slash)", func() {
-			args[0] = "download"
-			args[1] = "app_name"
-			args[2] = "/app/src/node/"
-			args[3] = "--verbose"
+			paths = make([]string, 1)
+			paths[0] = "/app/src/node/"
 			currentDirectory, _ := os.Getwd()
 			currentDirectory = filepath.ToSlash(currentDirectory)
-			localPath, rootWD, startingPath := GetDirectoryContext(currentDirectory, args, false)
+			pathVals := GetDirectoryContext(currentDirectory, paths, false)
 
-			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app/src/node/")
+			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryServer, "/cf-download/app/src/node/")
 			Expect(correctSuffix).To(BeTrue())
 
-			correctSuffix = strings.HasSuffix(localPath, "/cf-download/node/")
+			correctSuffix = strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/node/")
 			Expect(correctSuffix).To(BeTrue())
 
-			Expect(startingPath).To(Equal("/app/src/node/"))
+			Expect(pathVals[0].StartingPathServer).To(Equal("/app/src/node/"))
 		})
 
 		It("should still return /app/src/node/ for startingPath (INPUT only has trailing slash)", func() {
-			args[0] = "download"
-			args[1] = "app_name"
-			args[2] = "app/src/node/"
-			args[3] = "--verbose"
+			paths = make([]string, 1)
+			paths[0] = "app/src/node/"
 			currentDirectory, _ := os.Getwd()
 			currentDirectory = filepath.ToSlash(currentDirectory)
-			localPath, rootWD, startingPath := GetDirectoryContext(currentDirectory, args, false)
+			pathVals := GetDirectoryContext(currentDirectory, paths, false)
 
-			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app/src/node/")
+			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryServer, "/cf-download/app/src/node/")
 			Expect(correctSuffix).To(BeTrue())
 
-			correctSuffix = strings.HasSuffix(localPath, "/cf-download/node/")
+			correctSuffix = strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/node/")
 			Expect(correctSuffix).To(BeTrue())
 
-			Expect(startingPath).To(Equal("/app/src/node/"))
+			Expect(pathVals[0].StartingPathServer).To(Equal("/app/src/node/"))
 		})
 
 		It("should still return /app/src/node/ for startingPath (INPUT only has leading slash)", func() {
-			args[0] = "download"
-			args[1] = "app_name"
-			args[2] = "/app/src/node"
-			args[3] = "--verbose"
+			paths = make([]string, 1)
+			paths[0] = "/app/src/node"
 			currentDirectory, _ := os.Getwd()
 			currentDirectory = filepath.ToSlash(currentDirectory)
-			localPath, rootWD, startingPath := GetDirectoryContext(currentDirectory, args, false)
+			pathVals := GetDirectoryContext(currentDirectory, paths, false)
 
-			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app/src/node/")
+			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryServer, "/cf-download/app/src/node/")
 			Expect(correctSuffix).To(BeTrue())
 
-			correctSuffix = strings.HasSuffix(localPath, "/cf-download/node/")
+			correctSuffix = strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/node/")
 			Expect(correctSuffix).To(BeTrue())
 
-			Expect(startingPath).To(Equal("/app/src/node/"))
+			Expect(pathVals[0].StartingPathServer).To(Equal("/app/src/node/"))
 		})
 
 		It("should return /app/src/file.html for startingPath (--file flag specified)", func() {
-			args[0] = "download"
-			args[1] = "app_name"
-			args[2] = "/app/src/file.html"
-			args[3] = "--file"
+			paths = make([]string, 1)
+			paths[0] = "/app/src/file.html"
 			currentDirectory, _ := os.Getwd()
 			currentDirectory = filepath.ToSlash(currentDirectory)
-			localPath, rootWD, startingPath := GetDirectoryContext(currentDirectory, args, true)
+			pathVals := GetDirectoryContext(currentDirectory, paths, true)
 
-			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app/src/file.html")
+			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryServer, "/cf-download/app/src/file.html")
 			Expect(correctSuffix).To(BeTrue())
 
-			correctSuffix = strings.HasSuffix(localPath, "/cf-download/file.html")
+			correctSuffix = strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/file.html")
 			Expect(correctSuffix).To(BeTrue())
 
-			Expect(startingPath).To(Equal("/app/src/file.html"))
+			Expect(pathVals[0].StartingPathServer).To(Equal("/app/src/file.html"))
+		})
+
+		It("should return two staringPaths, /app/src/ and /app/logs/", func() {
+			paths = make([]string, 2)
+			paths[0] = "/app/src/"
+			paths[1] = "/app/logs/"
+			currentDirectory, _ := os.Getwd()
+			currentDirectory = filepath.ToSlash(currentDirectory)
+			pathVals := GetDirectoryContext(currentDirectory, paths, false)
+
+			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryServer, "/cf-download/app/src/")
+			Expect(correctSuffix).To(BeTrue())
+			correctSuffix = strings.HasSuffix(pathVals[1].RootWorkingDirectoryServer, "/cf-download/app/logs/")
+			Expect(correctSuffix).To(BeTrue())
+
+			correctSuffix = strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/src/")
+			Expect(correctSuffix).To(BeTrue())
+			correctSuffix = strings.HasSuffix(pathVals[1].RootWorkingDirectoryLocal, "/cf-download/logs/")
+			Expect(correctSuffix).To(BeTrue())
+
+			Expect(pathVals[0].StartingPathServer).To(Equal("/app/src/"))
+			Expect(pathVals[1].StartingPathServer).To(Equal("/app/logs/"))
 		})
 
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -1,12 +1,11 @@
 package main_test
 
 import (
+	. "github.com/ibmjstart/cf-download"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-
-	. "github.com/ibmjstart/cf-download"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -113,8 +112,7 @@ var _ = Describe("CfDownload", func() {
 			currentDirectory = filepath.ToSlash(currentDirectory)
 			rootWD, startingPath := GetDirectoryContext(currentDirectory, args, false)
 
-			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app-download/app/src/node/")
-
+			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app/src/node/")
 			Expect(correctSuffix).To(BeTrue())
 			Expect(startingPath).To(Equal("/app/src/node/"))
 		})
@@ -128,7 +126,7 @@ var _ = Describe("CfDownload", func() {
 			currentDirectory = filepath.ToSlash(currentDirectory)
 			rootWD, startingPath := GetDirectoryContext(currentDirectory, args, false)
 
-			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app-download/app/src/node/")
+			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app/src/node/")
 
 			Expect(correctSuffix).To(BeTrue())
 			Expect(startingPath).To(Equal("/app/src/node/"))
@@ -143,7 +141,7 @@ var _ = Describe("CfDownload", func() {
 			currentDirectory = filepath.ToSlash(currentDirectory)
 			rootWD, startingPath := GetDirectoryContext(currentDirectory, args, false)
 
-			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app-download/app/src/node/")
+			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app/src/node/")
 
 			Expect(correctSuffix).To(BeTrue())
 			Expect(startingPath).To(Equal("/app/src/node/"))
@@ -158,7 +156,7 @@ var _ = Describe("CfDownload", func() {
 			currentDirectory = filepath.ToSlash(currentDirectory)
 			rootWD, startingPath := GetDirectoryContext(currentDirectory, args, false)
 
-			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app-download/app/src/node/")
+			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app/src/node/")
 
 			Expect(correctSuffix).To(BeTrue())
 			Expect(startingPath).To(Equal("/app/src/node/"))
@@ -173,7 +171,7 @@ var _ = Describe("CfDownload", func() {
 			currentDirectory = filepath.ToSlash(currentDirectory)
 			rootWD, startingPath := GetDirectoryContext(currentDirectory, args, true)
 
-			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app-download/app/src/file.html")
+			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app/src/file.html")
 
 			Expect(correctSuffix).To(BeTrue())
 			Expect(startingPath).To(Equal("/app/src/file.html"))
@@ -197,14 +195,15 @@ var _ = Describe("CfDownload", func() {
 
 			It("Should print error, test overwrite flag functionality", func() {
 				// create directory that needs to be overwritten
-				os.Mkdir("test-download", 755)
+				os.Mkdir("test", 755)
 
 				cmd := exec.Command("cf", "download", "test")
 				output, _ := cmd.CombinedOutput()
-				Expect(strings.Contains(string(output), "already Exists and is not an empty directory.")).To(BeTrue())
 
 				// clean up
-				os.RemoveAll("test-download")
+				os.RemoveAll("test")
+
+				Expect(strings.Contains(string(output), "already exists.")).To(BeTrue())
 			})
 
 			It("Should print error, instance flag not int", func() {

--- a/main_test.go
+++ b/main_test.go
@@ -14,20 +14,13 @@ import (
 
 // unit tests of individual functions
 var _ = Describe("CfDownload", func() {
-	var args []string
-	var paths []string
-
 	Describe("Test ParseArgs functionality", func() {
 
 		Context("Check if overWrite flag works", func() {
 			It("Should set the overwrite_flag", func() {
-				args = make([]string, 4)
-				args[0] = "download"
-				args[1] = "app"
-				args[2] = "app/files/htdocs"
-				args[3] = "--overwrite"
+				args := [...]string{"download", "app", "app/files/htdocs", "--overwrite"}
 
-				flagVals, _ := ParseArgs(args)
+				flagVals, _ := ParseArgs(args[:])
 				Expect(flagVals.OverWrite_flag).To(BeTrue())
 				Expect(flagVals.File_flag).To(BeFalse())
 				Expect(flagVals.Instance_flag).To(Equal("0"))
@@ -38,12 +31,9 @@ var _ = Describe("CfDownload", func() {
 
 		Context("Check if file flag works", func() {
 			It("Should set the file_flag", func() {
-				args = make([]string, 3)
-				args[0] = "download"
-				args[1] = "app"
-				args[2] = "--file"
+				args := [...]string{"download", "app", "--file"}
 
-				flagVals, _ := ParseArgs(args)
+				flagVals, _ := ParseArgs(args[:])
 				Expect(flagVals.OverWrite_flag).To(BeFalse())
 				Expect(flagVals.File_flag).To(BeTrue())
 				Expect(flagVals.Instance_flag).To(Equal("0"))
@@ -54,12 +44,9 @@ var _ = Describe("CfDownload", func() {
 
 		Context("Check if verbose flag works", func() {
 			It("Should set the verbose_flag", func() {
-				args = make([]string, 3)
-				args[0] = "download"
-				args[1] = "app"
-				args[2] = "--verbose"
+				args := [...]string{"download", "app", "--verbose"}
 
-				flagVals, _ := ParseArgs(args)
+				flagVals, _ := ParseArgs(args[:])
 				Expect(flagVals.OverWrite_flag).To(BeFalse())
 				Expect(flagVals.File_flag).To(BeFalse())
 				Expect(flagVals.Instance_flag).To(Equal("0"))
@@ -70,13 +57,9 @@ var _ = Describe("CfDownload", func() {
 
 		Context("Check if instance (i) flag works", func() {
 			It("Should set the instance_flag", func() {
-				args = make([]string, 4)
-				args[0] = "download"
-				args[1] = "app"
-				args[2] = "--i"
-				args[3] = "3"
+				args := [...]string{"download", "app", "--i", "3"}
 
-				flagVals, _ := ParseArgs(args)
+				flagVals, _ := ParseArgs(args[:])
 				Expect(flagVals.OverWrite_flag).To(BeFalse())
 				Expect(flagVals.File_flag).To(BeFalse())
 				Expect(flagVals.Instance_flag).To(Equal("3"))
@@ -87,13 +70,9 @@ var _ = Describe("CfDownload", func() {
 
 		Context("Check if omit flag works", func() {
 			It("Should set the omit_flag", func() {
-				args = make([]string, 4)
-				args[0] = "download"
-				args[1] = "app"
-				args[2] = "--omit"
-				args[3] = "app/node_modules"
+				args := [...]string{"download", "app", "--omit", "app/node_modules"}
 
-				flagVals, _ := ParseArgs(args)
+				flagVals, _ := ParseArgs(args[:])
 				Expect(flagVals.OverWrite_flag).To(BeFalse())
 				Expect(flagVals.File_flag).To(BeFalse())
 				Expect(flagVals.Instance_flag).To(Equal("0"))
@@ -104,32 +83,23 @@ var _ = Describe("CfDownload", func() {
 
 		Context("Check if correct number of paths are returned", func() {
 			It("Should return 0 paths", func() {
-				args = make([]string, 2)
-				args[0] = "download"
-				args[1] = "app"
+				args := [...]string{"download", "app"}
 
-				_, paths := ParseArgs(args)
+				_, paths := ParseArgs(args[:])
 				Expect(len(paths)).To(Equal(0))
 			})
 
 			It("Should return 1 path", func() {
-				args = make([]string, 3)
-				args[0] = "download"
-				args[1] = "app"
-				args[2] = "path/to/file"
+				args := [...]string{"download", "app", "path/to/file"}
 
-				_, paths := ParseArgs(args)
+				_, paths := ParseArgs(args[:])
 				Expect(len(paths)).To(Equal(1))
 			})
 
 			It("Should return 2 paths", func() {
-				args = make([]string, 4)
-				args[0] = "download"
-				args[1] = "app"
-				args[2] = "path/to/file"
-				args[3] = "path/to/other/file"
+				args := [...]string{"download", "app", "path/to/file", "path/to/other/file"}
 
-				_, paths := ParseArgs(args)
+				_, paths := ParseArgs(args[:])
 				Expect(len(paths)).To(Equal(2))
 			})
 		})
@@ -138,11 +108,11 @@ var _ = Describe("CfDownload", func() {
 	Describe("test directoryContext parsing", func() {
 
 		It("Should return correct strings", func() {
-			paths = make([]string, 1)
-			paths[0] = "app/src/node"
+			paths := [...]string{"app/src/node"}
+
 			currentDirectory, _ := os.Getwd()
 			currentDirectory = filepath.ToSlash(currentDirectory)
-			pathVals := GetDirectoryContext(currentDirectory, paths, false)
+			pathVals := GetDirectoryContext(currentDirectory, paths[:], false)
 
 			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/node/")
 			Expect(correctSuffix).To(BeTrue())
@@ -151,11 +121,11 @@ var _ = Describe("CfDownload", func() {
 		})
 
 		It("should still return /app/src/node/ for startingPath (INPUT has leading and trailing slash)", func() {
-			paths = make([]string, 1)
-			paths[0] = "/app/src/node/"
+			paths := [...]string{"/app/src/node/"}
+
 			currentDirectory, _ := os.Getwd()
 			currentDirectory = filepath.ToSlash(currentDirectory)
-			pathVals := GetDirectoryContext(currentDirectory, paths, false)
+			pathVals := GetDirectoryContext(currentDirectory, paths[:], false)
 
 			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/node/")
 			Expect(correctSuffix).To(BeTrue())
@@ -164,11 +134,11 @@ var _ = Describe("CfDownload", func() {
 		})
 
 		It("should still return /app/src/node/ for startingPath (INPUT only has trailing slash)", func() {
-			paths = make([]string, 1)
-			paths[0] = "app/src/node/"
+			paths := [...]string{"app/src/node/"}
+
 			currentDirectory, _ := os.Getwd()
 			currentDirectory = filepath.ToSlash(currentDirectory)
-			pathVals := GetDirectoryContext(currentDirectory, paths, false)
+			pathVals := GetDirectoryContext(currentDirectory, paths[:], false)
 
 			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/node/")
 			Expect(correctSuffix).To(BeTrue())
@@ -177,11 +147,11 @@ var _ = Describe("CfDownload", func() {
 		})
 
 		It("should still return /app/src/node/ for startingPath (INPUT only has leading slash)", func() {
-			paths = make([]string, 1)
-			paths[0] = "/app/src/node"
+			paths := [...]string{"/app/src/node"}
+
 			currentDirectory, _ := os.Getwd()
 			currentDirectory = filepath.ToSlash(currentDirectory)
-			pathVals := GetDirectoryContext(currentDirectory, paths, false)
+			pathVals := GetDirectoryContext(currentDirectory, paths[:], false)
 
 			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/node/")
 			Expect(correctSuffix).To(BeTrue())
@@ -190,11 +160,11 @@ var _ = Describe("CfDownload", func() {
 		})
 
 		It("should return /app/src/file.html for startingPath (--file flag specified)", func() {
-			paths = make([]string, 1)
-			paths[0] = "/app/src/file.html"
+			paths := [...]string{"/app/src/file.html"}
+
 			currentDirectory, _ := os.Getwd()
 			currentDirectory = filepath.ToSlash(currentDirectory)
-			pathVals := GetDirectoryContext(currentDirectory, paths, true)
+			pathVals := GetDirectoryContext(currentDirectory, paths[:], true)
 
 			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/file.html")
 			Expect(correctSuffix).To(BeTrue())
@@ -203,12 +173,11 @@ var _ = Describe("CfDownload", func() {
 		})
 
 		It("should return two staringPaths, /app/src/ and /app/logs/", func() {
-			paths = make([]string, 2)
-			paths[0] = "/app/src/"
-			paths[1] = "/app/logs/"
+			paths := [...]string{"/app/src/", "app/logs/"}
+
 			currentDirectory, _ := os.Getwd()
 			currentDirectory = filepath.ToSlash(currentDirectory)
-			pathVals := GetDirectoryContext(currentDirectory, paths, false)
+			pathVals := GetDirectoryContext(currentDirectory, paths[:], false)
 
 			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/src/")
 			Expect(correctSuffix).To(BeTrue())

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main_test
 
 import (
 	. "github.com/ibmjstart/cf-download"
+	"github.com/ibmjstart/cf-download/cmd_exec/cmd_exec_fake"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -238,6 +239,27 @@ var _ = Describe("CfDownload", func() {
 			Expect(pathVals[1].StartingPathServer).To(Equal("/app/logs/"))
 		})
 
+	})
+
+	Describe("test expandGlobs parsing", func() {
+		It("should return x.txt, y.txt, a.go and ab.go", func() {
+			cmdExec := cmd_exec_fake.NewCmdExec()
+			cmdExec.SetOutput("Getting files for app Test in org test / space dev as user...\nOK\n\nxyz.txt                                   220B\na.go                                      675B\nab.go                                     333B\nyz.go                                     123B\n\n")
+			cmdExec.SetFakeDir(false)
+
+			paths := make([]string, 1)
+			paths[0] = "*.txt"
+			paths = ExpandGlobs(cmdExec, paths, "0")
+			Expect(paths[0]).To(Equal("./xyz.txt"))
+
+			paths[0] = "?.go"
+			paths = ExpandGlobs(cmdExec, paths, "0")
+			Expect(paths[0]).To(Equal("./a.go"))
+
+			paths[0] = "[a-z]b.go"
+			paths = ExpandGlobs(cmdExec, paths, "0")
+			Expect(paths[0]).To(Equal("./ab.go"))
+		})
 	})
 
 	Describe("test error catching in run() [MUST HAVE PLUGIN INSTALLED TO PASS]", func() {

--- a/main_test.go
+++ b/main_test.go
@@ -110,10 +110,14 @@ var _ = Describe("CfDownload", func() {
 			args[3] = "--verbose"
 			currentDirectory, _ := os.Getwd()
 			currentDirectory = filepath.ToSlash(currentDirectory)
-			rootWD, startingPath := GetDirectoryContext(currentDirectory, args, false)
+			localPath, rootWD, startingPath := GetDirectoryContext(currentDirectory, args, false)
 
 			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app/src/node/")
 			Expect(correctSuffix).To(BeTrue())
+
+			correctSuffix = strings.HasSuffix(localPath, "/cf-download/node/")
+			Expect(correctSuffix).To(BeTrue())
+
 			Expect(startingPath).To(Equal("/app/src/node/"))
 		})
 
@@ -124,11 +128,14 @@ var _ = Describe("CfDownload", func() {
 			args[3] = "--verbose"
 			currentDirectory, _ := os.Getwd()
 			currentDirectory = filepath.ToSlash(currentDirectory)
-			rootWD, startingPath := GetDirectoryContext(currentDirectory, args, false)
+			localPath, rootWD, startingPath := GetDirectoryContext(currentDirectory, args, false)
 
 			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app/src/node/")
-
 			Expect(correctSuffix).To(BeTrue())
+
+			correctSuffix = strings.HasSuffix(localPath, "/cf-download/node/")
+			Expect(correctSuffix).To(BeTrue())
+
 			Expect(startingPath).To(Equal("/app/src/node/"))
 		})
 
@@ -139,11 +146,14 @@ var _ = Describe("CfDownload", func() {
 			args[3] = "--verbose"
 			currentDirectory, _ := os.Getwd()
 			currentDirectory = filepath.ToSlash(currentDirectory)
-			rootWD, startingPath := GetDirectoryContext(currentDirectory, args, false)
+			localPath, rootWD, startingPath := GetDirectoryContext(currentDirectory, args, false)
 
 			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app/src/node/")
-
 			Expect(correctSuffix).To(BeTrue())
+
+			correctSuffix = strings.HasSuffix(localPath, "/cf-download/node/")
+			Expect(correctSuffix).To(BeTrue())
+
 			Expect(startingPath).To(Equal("/app/src/node/"))
 		})
 
@@ -154,11 +164,14 @@ var _ = Describe("CfDownload", func() {
 			args[3] = "--verbose"
 			currentDirectory, _ := os.Getwd()
 			currentDirectory = filepath.ToSlash(currentDirectory)
-			rootWD, startingPath := GetDirectoryContext(currentDirectory, args, false)
+			localPath, rootWD, startingPath := GetDirectoryContext(currentDirectory, args, false)
 
 			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app/src/node/")
-
 			Expect(correctSuffix).To(BeTrue())
+
+			correctSuffix = strings.HasSuffix(localPath, "/cf-download/node/")
+			Expect(correctSuffix).To(BeTrue())
+
 			Expect(startingPath).To(Equal("/app/src/node/"))
 		})
 
@@ -169,11 +182,14 @@ var _ = Describe("CfDownload", func() {
 			args[3] = "--file"
 			currentDirectory, _ := os.Getwd()
 			currentDirectory = filepath.ToSlash(currentDirectory)
-			rootWD, startingPath := GetDirectoryContext(currentDirectory, args, true)
+			localPath, rootWD, startingPath := GetDirectoryContext(currentDirectory, args, true)
 
 			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app/src/file.html")
-
 			Expect(correctSuffix).To(BeTrue())
+
+			correctSuffix = strings.HasSuffix(localPath, "/cf-download/file.html")
+			Expect(correctSuffix).To(BeTrue())
+
 			Expect(startingPath).To(Equal("/app/src/file.html"))
 		})
 

--- a/main_test.go
+++ b/main_test.go
@@ -144,10 +144,7 @@ var _ = Describe("CfDownload", func() {
 			currentDirectory = filepath.ToSlash(currentDirectory)
 			pathVals := GetDirectoryContext(currentDirectory, paths, false)
 
-			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryServer, "/cf-download/app/src/node/")
-			Expect(correctSuffix).To(BeTrue())
-
-			correctSuffix = strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/node/")
+			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/node/")
 			Expect(correctSuffix).To(BeTrue())
 
 			Expect(pathVals[0].StartingPathServer).To(Equal("/app/src/node/"))
@@ -160,10 +157,7 @@ var _ = Describe("CfDownload", func() {
 			currentDirectory = filepath.ToSlash(currentDirectory)
 			pathVals := GetDirectoryContext(currentDirectory, paths, false)
 
-			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryServer, "/cf-download/app/src/node/")
-			Expect(correctSuffix).To(BeTrue())
-
-			correctSuffix = strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/node/")
+			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/node/")
 			Expect(correctSuffix).To(BeTrue())
 
 			Expect(pathVals[0].StartingPathServer).To(Equal("/app/src/node/"))
@@ -176,10 +170,7 @@ var _ = Describe("CfDownload", func() {
 			currentDirectory = filepath.ToSlash(currentDirectory)
 			pathVals := GetDirectoryContext(currentDirectory, paths, false)
 
-			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryServer, "/cf-download/app/src/node/")
-			Expect(correctSuffix).To(BeTrue())
-
-			correctSuffix = strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/node/")
+			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/node/")
 			Expect(correctSuffix).To(BeTrue())
 
 			Expect(pathVals[0].StartingPathServer).To(Equal("/app/src/node/"))
@@ -192,10 +183,7 @@ var _ = Describe("CfDownload", func() {
 			currentDirectory = filepath.ToSlash(currentDirectory)
 			pathVals := GetDirectoryContext(currentDirectory, paths, false)
 
-			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryServer, "/cf-download/app/src/node/")
-			Expect(correctSuffix).To(BeTrue())
-
-			correctSuffix = strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/node/")
+			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/node/")
 			Expect(correctSuffix).To(BeTrue())
 
 			Expect(pathVals[0].StartingPathServer).To(Equal("/app/src/node/"))
@@ -208,10 +196,7 @@ var _ = Describe("CfDownload", func() {
 			currentDirectory = filepath.ToSlash(currentDirectory)
 			pathVals := GetDirectoryContext(currentDirectory, paths, true)
 
-			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryServer, "/cf-download/app/src/file.html")
-			Expect(correctSuffix).To(BeTrue())
-
-			correctSuffix = strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/file.html")
+			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/file.html")
 			Expect(correctSuffix).To(BeTrue())
 
 			Expect(pathVals[0].StartingPathServer).To(Equal("/app/src/file.html"))
@@ -225,12 +210,7 @@ var _ = Describe("CfDownload", func() {
 			currentDirectory = filepath.ToSlash(currentDirectory)
 			pathVals := GetDirectoryContext(currentDirectory, paths, false)
 
-			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryServer, "/cf-download/app/src/")
-			Expect(correctSuffix).To(BeTrue())
-			correctSuffix = strings.HasSuffix(pathVals[1].RootWorkingDirectoryServer, "/cf-download/app/logs/")
-			Expect(correctSuffix).To(BeTrue())
-
-			correctSuffix = strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/src/")
+			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/src/")
 			Expect(correctSuffix).To(BeTrue())
 			correctSuffix = strings.HasSuffix(pathVals[1].RootWorkingDirectoryLocal, "/cf-download/logs/")
 			Expect(correctSuffix).To(BeTrue())

--- a/main_test.go
+++ b/main_test.go
@@ -3,8 +3,8 @@ package main_test
 import (
 	"os"
 	"os/exec"
-	"strings"
 	"path/filepath"
+	"strings"
 
 	. "github.com/ibmjstart/cf-download"
 
@@ -31,6 +31,22 @@ var _ = Describe("CfDownload", func() {
 
 				flagVals := ParseFlags(args)
 				Expect(flagVals.OverWrite_flag).To(BeTrue())
+				Expect(flagVals.File_flag).To(BeFalse())
+				Expect(flagVals.Instance_flag).To(Equal("0"))
+				Expect(flagVals.Verbose_flag).To(BeFalse())
+				Expect(flagVals.Omit_flag).To(Equal(""))
+			})
+		})
+
+		Context("Check if file flag works", func() {
+			It("Should set the file_flag", func() {
+				args[0] = "download"
+				args[1] = "app"
+				args[2] = "--file"
+
+				flagVals := ParseFlags(args)
+				Expect(flagVals.OverWrite_flag).To(BeFalse())
+				Expect(flagVals.File_flag).To(BeTrue())
 				Expect(flagVals.Instance_flag).To(Equal("0"))
 				Expect(flagVals.Verbose_flag).To(BeFalse())
 				Expect(flagVals.Omit_flag).To(Equal(""))
@@ -45,6 +61,7 @@ var _ = Describe("CfDownload", func() {
 
 				flagVals := ParseFlags(args)
 				Expect(flagVals.OverWrite_flag).To(BeFalse())
+				Expect(flagVals.File_flag).To(BeFalse())
 				Expect(flagVals.Instance_flag).To(Equal("0"))
 				Expect(flagVals.Verbose_flag).To(BeTrue())
 				Expect(flagVals.Omit_flag).To(Equal(""))
@@ -60,6 +77,7 @@ var _ = Describe("CfDownload", func() {
 
 				flagVals := ParseFlags(args)
 				Expect(flagVals.OverWrite_flag).To(BeFalse())
+				Expect(flagVals.File_flag).To(BeFalse())
 				Expect(flagVals.Instance_flag).To(Equal("3"))
 				Expect(flagVals.Verbose_flag).To(BeFalse())
 				Expect(flagVals.Omit_flag).To(Equal(""))
@@ -75,6 +93,7 @@ var _ = Describe("CfDownload", func() {
 
 				flagVals := ParseFlags(args)
 				Expect(flagVals.OverWrite_flag).To(BeFalse())
+				Expect(flagVals.File_flag).To(BeFalse())
 				Expect(flagVals.Instance_flag).To(Equal("0"))
 				Expect(flagVals.Verbose_flag).To(BeFalse())
 				Expect(flagVals.Omit_flag).To(Equal("app/node_modules"))
@@ -92,7 +111,7 @@ var _ = Describe("CfDownload", func() {
 			args[3] = "--verbose"
 			currentDirectory, _ := os.Getwd()
 			currentDirectory = filepath.ToSlash(currentDirectory)
-			rootWD, startingPath := GetDirectoryContext(currentDirectory, args)
+			rootWD, startingPath := GetDirectoryContext(currentDirectory, args, false)
 
 			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app-download/app/src/node/")
 
@@ -107,7 +126,7 @@ var _ = Describe("CfDownload", func() {
 			args[3] = "--verbose"
 			currentDirectory, _ := os.Getwd()
 			currentDirectory = filepath.ToSlash(currentDirectory)
-			rootWD, startingPath := GetDirectoryContext(currentDirectory, args)
+			rootWD, startingPath := GetDirectoryContext(currentDirectory, args, false)
 
 			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app-download/app/src/node/")
 
@@ -122,7 +141,7 @@ var _ = Describe("CfDownload", func() {
 			args[3] = "--verbose"
 			currentDirectory, _ := os.Getwd()
 			currentDirectory = filepath.ToSlash(currentDirectory)
-			rootWD, startingPath := GetDirectoryContext(currentDirectory, args)
+			rootWD, startingPath := GetDirectoryContext(currentDirectory, args, false)
 
 			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app-download/app/src/node/")
 
@@ -137,12 +156,27 @@ var _ = Describe("CfDownload", func() {
 			args[3] = "--verbose"
 			currentDirectory, _ := os.Getwd()
 			currentDirectory = filepath.ToSlash(currentDirectory)
-			rootWD, startingPath := GetDirectoryContext(currentDirectory, args)
+			rootWD, startingPath := GetDirectoryContext(currentDirectory, args, false)
 
 			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app-download/app/src/node/")
 
 			Expect(correctSuffix).To(BeTrue())
 			Expect(startingPath).To(Equal("/app/src/node/"))
+		})
+
+		It("should return /app/src/file.html for startingPath (--file flag specified)", func() {
+			args[0] = "download"
+			args[1] = "app_name"
+			args[2] = "/app/src/file.html"
+			args[3] = "--file"
+			currentDirectory, _ := os.Getwd()
+			currentDirectory = filepath.ToSlash(currentDirectory)
+			rootWD, startingPath := GetDirectoryContext(currentDirectory, args, true)
+
+			correctSuffix := strings.HasSuffix(rootWD, "/cf-download/app-download/app/src/file.html")
+
+			Expect(correctSuffix).To(BeTrue())
+			Expect(startingPath).To(Equal("/app/src/file.html"))
 		})
 
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -114,7 +114,7 @@ var _ = Describe("CfDownload", func() {
 			currentDirectory = filepath.ToSlash(currentDirectory)
 			pathVals := GetDirectoryContext(currentDirectory, paths[:], false)
 
-			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/node/")
+			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, filepath.FromSlash("/cf-download/node/"))
 			Expect(correctSuffix).To(BeTrue())
 
 			Expect(pathVals[0].StartingPathServer).To(Equal("/app/src/node/"))
@@ -127,7 +127,7 @@ var _ = Describe("CfDownload", func() {
 			currentDirectory = filepath.ToSlash(currentDirectory)
 			pathVals := GetDirectoryContext(currentDirectory, paths[:], false)
 
-			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/node/")
+			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, filepath.FromSlash("/cf-download/node/"))
 			Expect(correctSuffix).To(BeTrue())
 
 			Expect(pathVals[0].StartingPathServer).To(Equal("/app/src/node/"))
@@ -140,7 +140,7 @@ var _ = Describe("CfDownload", func() {
 			currentDirectory = filepath.ToSlash(currentDirectory)
 			pathVals := GetDirectoryContext(currentDirectory, paths[:], false)
 
-			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/node/")
+			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, filepath.FromSlash("/cf-download/node/"))
 			Expect(correctSuffix).To(BeTrue())
 
 			Expect(pathVals[0].StartingPathServer).To(Equal("/app/src/node/"))
@@ -153,7 +153,7 @@ var _ = Describe("CfDownload", func() {
 			currentDirectory = filepath.ToSlash(currentDirectory)
 			pathVals := GetDirectoryContext(currentDirectory, paths[:], false)
 
-			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/node/")
+			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, filepath.FromSlash("/cf-download/node/"))
 			Expect(correctSuffix).To(BeTrue())
 
 			Expect(pathVals[0].StartingPathServer).To(Equal("/app/src/node/"))
@@ -166,7 +166,7 @@ var _ = Describe("CfDownload", func() {
 			currentDirectory = filepath.ToSlash(currentDirectory)
 			pathVals := GetDirectoryContext(currentDirectory, paths[:], true)
 
-			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/file.html")
+			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, filepath.FromSlash("/cf-download/file.html"))
 			Expect(correctSuffix).To(BeTrue())
 
 			Expect(pathVals[0].StartingPathServer).To(Equal("/app/src/file.html"))
@@ -179,9 +179,9 @@ var _ = Describe("CfDownload", func() {
 			currentDirectory = filepath.ToSlash(currentDirectory)
 			pathVals := GetDirectoryContext(currentDirectory, paths[:], false)
 
-			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, "/cf-download/src/")
+			correctSuffix := strings.HasSuffix(pathVals[0].RootWorkingDirectoryLocal, filepath.FromSlash("/cf-download/src/"))
 			Expect(correctSuffix).To(BeTrue())
-			correctSuffix = strings.HasSuffix(pathVals[1].RootWorkingDirectoryLocal, "/cf-download/logs/")
+			correctSuffix = strings.HasSuffix(pathVals[1].RootWorkingDirectoryLocal, filepath.FromSlash("/cf-download/logs/"))
 			Expect(correctSuffix).To(BeTrue())
 
 			Expect(pathVals[0].StartingPathServer).To(Equal("/app/src/"))


### PR DESCRIPTION
PATH now supports paths to single files within the application to be downloaded. PATH also supports globs at the base of the file path. Multiple paths can be given as input.
